### PR TITLE
Update Support option from Slack to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Again, this repo is intended for bugs and feature requests. If you have a suppor
 * Check out the [documentation](https://docs.statamic.com/). It even has a search function! 
 * Post on [The Lodge, our official support Forum](https://statamic.com/forum) - Be sure to do a search for your question first, it may have already been answered!
 * If it's private or sensitive, you can submit an [official support request](https://statamic.com/support) or shoot an email to [support@statamic.com](mailto:support@statamic.com)
-* Hop into the [Slack Chat](https://statamic.slack.com/). If you have a quick question or just want to chat, the community may be able to lend a hand. [Request an invite here](http://slack.statamic.com/).
+* Hop into the [Discord Chat](https://statamic.com/discord). If you have a quick question or just want to chat, the community may be able to lend a hand. [Join here](https://statamic.com/discord).


### PR DESCRIPTION
Statamic [recently announced](https://statamic.com/blog/goodbye-slack-hello-discord) they would be switching from Slack to Discord. 

The new links reflect that change.